### PR TITLE
Refactor exports to ESM named exports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,5 +4,9 @@
   "env": {
     "node": true,
     "jest": true
+  },
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaVersion": 2020
   }
 }

--- a/lib/camelot-engine.js
+++ b/lib/camelot-engine.js
@@ -1,12 +1,4 @@
-'use strict';
-
-function camelotEngine() {
-  return {
-    createEmptyGame: require('./init/create-empty-game'),
-    query: require('./query/query'),
-    update: require('./update/update'),
-    constants: require('./get-constants'),
-  };
-}
-
-module.exports = camelotEngine;
+export { default as createEmptyGame } from './init/create-empty-game.js';
+export * from './query/query.js';
+export { applyMoves } from './update/update.js';
+export { default as constants } from './get-constants.js';

--- a/lib/get-constants.js
+++ b/lib/get-constants.js
@@ -1,6 +1,4 @@
-'use strict';
-
-function getConstants() {
+export default function getConstants() {
   const BOARD_HEIGHT = 17,
     PLAYER_A = 'playerA',
     PLAYER_B = 'playerB';
@@ -48,5 +46,3 @@ function getConstants() {
     ],
   };
 }
-
-module.exports = getConstants;

--- a/lib/init/create-board-spaces.js
+++ b/lib/init/create-board-spaces.js
@@ -1,9 +1,7 @@
-'use strict';
+import _ from 'lodash';
+import getRangeForRow from './get-range-for-row.js';
 
-const _ = require('lodash'),
-  getRangeForRow = require('./get-range-for-row');
-
-function getBoardSpaces() {
+export default function getBoardSpaces() {
   // TODO verify that this is actually correct
 
   return _.flatten([
@@ -18,5 +16,3 @@ function getBoardSpaces() {
     getRangeForRow(16, 5),
   ]);
 }
-
-module.exports = getBoardSpaces;

--- a/lib/init/create-empty-game.js
+++ b/lib/init/create-empty-game.js
@@ -1,11 +1,11 @@
-'use strict';
+import createBoardSpaces from './create-board-spaces.js';
+import withStartingPieces from './with-starting-pieces.js';
+import getConstants from '../get-constants.js';
+import _ from 'lodash';
 
-const createBoardSpaces = require('./create-board-spaces'),
-  withStartingPieces = require('./with-starting-pieces'),
-  constants = require('../get-constants')(),
-  _ = require('lodash');
+const constants = getConstants();
 
-function createEmptyGame() {
+export default function createEmptyGame() {
   const capturedPieces = _([constants.PLAYER_A, constants.PLAYER_B])
     .map(function (playerName) {
       return [playerName, { [constants.PAWN]: 0, [constants.KNIGHT]: 0 }];
@@ -19,5 +19,3 @@ function createEmptyGame() {
     boardSpaces: createBoardSpaces(),
   });
 }
-
-module.exports = createEmptyGame;

--- a/lib/init/get-range-for-row.js
+++ b/lib/init/get-range-for-row.js
@@ -1,7 +1,5 @@
-'use strict';
-
-const _ = require('lodash'),
-  getConstants = require('../get-constants');
+import _ from 'lodash';
+import getConstants from '../get-constants.js';
 
 function createBoardSpace(row, col) {
   return {
@@ -11,11 +9,9 @@ function createBoardSpace(row, col) {
   };
 }
 
-function getRangeForRow(row, firstCol) {
+export default function getRangeForRow(row, firstCol) {
   const lastCol = getConstants().BOARD_WIDTH - firstCol;
   return _.map(_.range(firstCol, lastCol), function (col) {
     return createBoardSpace(row, col);
   });
 }
-
-module.exports = getRangeForRow;

--- a/lib/init/with-starting-pieces.js
+++ b/lib/init/with-starting-pieces.js
@@ -1,9 +1,9 @@
-'use strict';
+import updateBoardSpace from '../update/update-board-space.js';
+import getConstants from '../get-constants.js';
+import repeat from '../util/repeat.js';
+import _ from 'lodash';
 
-const updateBoardSpace = require('../update/update-board-space'),
-  constants = require('../get-constants')(),
-  repeat = require('../util/repeat'),
-  _ = require('lodash');
+const constants = getConstants();
 
 function makePieceRow(gameState, countPawns, row, colStart, player) {
   const pieces = [constants.KNIGHT]
@@ -25,7 +25,7 @@ function makePieceRow(gameState, countPawns, row, colStart, player) {
   );
 }
 
-function withStartingPieces(gameState) {
+export default function withStartingPieces(gameState) {
   return _.reduce(
     constants.STARTING_POSITIONS,
     function (gameStateAcc, startingPosition) {
@@ -40,5 +40,3 @@ function withStartingPieces(gameState) {
     gameState
   );
 }
-
-module.exports = withStartingPieces;

--- a/lib/query/get-all-board-spaces.js
+++ b/lib/query/get-all-board-spaces.js
@@ -1,7 +1,3 @@
-'use strict';
-
-function getAllBoardSpaces(gameState) {
+export default function getAllBoardSpaces(gameState) {
   return gameState.boardSpaces;
 }
-
-module.exports = getAllBoardSpaces;

--- a/lib/query/get-board-space.js
+++ b/lib/query/get-board-space.js
@@ -1,8 +1,10 @@
-'use strict';
+import _ from 'lodash';
 
-const _ = require('lodash');
-
-function getBoardSpace(gameState, rowOrBoardSpaceObj, colOrUndefined) {
+export default function getBoardSpace(
+  gameState,
+  rowOrBoardSpaceObj,
+  colOrUndefined
+) {
   let row, col;
 
   if (_.isObject(rowOrBoardSpaceObj)) {
@@ -15,5 +17,3 @@ function getBoardSpace(gameState, rowOrBoardSpaceObj, colOrUndefined) {
 
   return _.find(gameState.boardSpaces, { row, col }) || null;
 }
-
-module.exports = getBoardSpace;

--- a/lib/query/get-coords-between.js
+++ b/lib/query/get-coords-between.js
@@ -1,6 +1,4 @@
-'use strict';
-
-function getCoordsBetween(space1, space2) {
+export default function getCoordsBetween(space1, space2) {
   let moveDelta = {
       row: space2.row - space1.row,
       col: space2.col - space1.col,
@@ -36,5 +34,3 @@ function getCoordsBetween(space1, space2) {
     col: space1.col + offset.col,
   };
 }
-
-module.exports = getCoordsBetween;

--- a/lib/query/get-game-winner.js
+++ b/lib/query/get-game-winner.js
@@ -1,11 +1,11 @@
-'use strict';
+import _ from 'lodash';
+import getAllBoardSpaces from './get-all-board-spaces.js';
+import util from 'util';
+import getConstants from '../get-constants.js';
 
-const _ = require('lodash'),
-  getAllBoardSpaces = require('./get-all-board-spaces'),
-  util = require('util'),
-  constants = require('../get-constants')();
+const constants = getConstants();
 
-function getGameWinner(gameState) {
+export default function getGameWinner(gameState) {
   function hasEnoughPieces(player) {
     return (
       _.filter(getAllBoardSpaces(gameState), function (boardPiece) {
@@ -39,5 +39,3 @@ function getGameWinner(gameState) {
 
   return null;
 }
-
-module.exports = getGameWinner;

--- a/lib/query/is-goal.js
+++ b/lib/query/is-goal.js
@@ -1,11 +1,9 @@
-'use strict';
+import getBoardSpace from './get-board-space.js';
+import _ from 'lodash';
+import util from 'util';
+import getAllBoardSpaces from './get-all-board-spaces.js';
 
-const getBoardSpace = require('./get-board-space'),
-  _ = require('lodash'),
-  util = require('util'),
-  getAllBoardSpaces = require('./get-all-board-spaces');
-
-function isGoal(gameState, row, col) {
+export default function isGoal(gameState, row, col) {
   if (!_.isObject(gameState)) {
     throw new Error(
       `isGoal: gameState must be an object representing the game state, but was: \`${util.inspect(
@@ -24,5 +22,3 @@ function isGoal(gameState, row, col) {
           .valueOf())
   );
 }
-
-module.exports = isGoal;

--- a/lib/query/is-valid-move.js
+++ b/lib/query/is-valid-move.js
@@ -1,12 +1,12 @@
-'use strict';
+import applyMove from '../update/apply-move.js';
+import getBoardSpace from './get-board-space.js';
+import getConstants from '../get-constants.js';
+import getCoordsBetween from './get-coords-between.js';
+import _ from 'lodash';
 
-const applyMove = require('../update/apply-move'),
-  getBoardSpace = require('./get-board-space'),
-  constants = require('../get-constants')(),
-  getCoordsBetween = require('./get-coords-between'),
-  _ = require('lodash');
+const constants = getConstants();
 
-function isValidMove(gameState, moveParts, movingPlayer) {
+export default function isValidMove(gameState, moveParts, movingPlayer) {
   function isValidMoveRec(
     gameState,
     moveParts,
@@ -126,5 +126,3 @@ function isValidMove(gameState, moveParts, movingPlayer) {
 
   return isValidMoveRec(gameState, moveParts, null, false, true);
 }
-
-module.exports = isValidMove;

--- a/lib/query/query.js
+++ b/lib/query/query.js
@@ -1,14 +1,6 @@
-'use strict';
-
-function query() {
-  return {
-    isGoal: require('./is-goal'),
-    isValidMove: require('./is-valid-move'),
-    getGameWinner: require('./get-game-winner'),
-    getBoardSpace: require('./get-board-space'),
-    getAllBoardSpaces: require('./get-all-board-spaces'),
-    getCoordsBetween: require('./get-coords-between'),
-  };
-}
-
-module.exports = query;
+export { default as isGoal } from './is-goal.js';
+export { default as isValidMove } from './is-valid-move.js';
+export { default as getGameWinner } from './get-game-winner.js';
+export { default as getBoardSpace } from './get-board-space.js';
+export { default as getAllBoardSpaces } from './get-all-board-spaces.js';
+export { default as getCoordsBetween } from './get-coords-between.js';

--- a/lib/update/apply-move.js
+++ b/lib/update/apply-move.js
@@ -1,12 +1,10 @@
-'use strict';
+import getBoardSpace from '../query/get-board-space.js';
+import util from 'util';
+import getCoordsBetween from '../query/get-coords-between.js';
+import updateBoardSpace from './update-board-space.js';
+import _ from 'lodash';
 
-const getBoardSpace = require('../query/get-board-space'),
-  util = require('util'),
-  getCoordsBetween = require('../query/get-coords-between'),
-  updateBoardSpace = require('./update-board-space'),
-  _ = require('lodash');
-
-function applyMove(gameState, moveStart, moveEnd) {
+export default function applyMove(gameState, moveStart, moveEnd) {
   let movingPiece = getBoardSpace(gameState, moveStart).piece,
     withMovingPieceNotAtSrc = updateBoardSpace(
       gameState,
@@ -61,5 +59,3 @@ function applyMove(gameState, moveStart, moveEnd) {
 
   return withMovingPieceAtDest;
 }
-
-module.exports = applyMove;

--- a/lib/update/apply-moves.js
+++ b/lib/update/apply-moves.js
@@ -1,10 +1,8 @@
-'use strict';
+import applyMove from './apply-move.js';
+import _ from 'lodash';
+import pairwise from '../util/pairwise.js';
 
-const applyMove = require('./apply-move'),
-  _ = require('lodash'),
-  pairwise = require('../util/pairwise');
-
-function applyMoves(gameState, moves) {
+export default function applyMoves(gameState, moves) {
   // TODO it would be nice to throw an error if the moves aren't valid.
 
   let movePairs, nextGameState;
@@ -29,5 +27,3 @@ function applyMoves(gameState, moves) {
     nextGameState
   );
 }
-
-module.exports = applyMoves;

--- a/lib/update/update-board-space.js
+++ b/lib/update/update-board-space.js
@@ -1,14 +1,10 @@
-'use strict';
+import _ from 'lodash';
+import getBoardSpace from '../query/get-board-space.js';
 
-const _ = require('lodash'),
-  getBoardSpace = require('../query/get-board-space');
-
-function updateBoardSpace(gameState, row, col, newBoardSpace) {
+export default function updateBoardSpace(gameState, row, col, newBoardSpace) {
   const newGameState = _.cloneDeep(gameState);
 
   _.merge(getBoardSpace(newGameState, row, col), newBoardSpace);
 
   return newGameState;
 }
-
-module.exports = updateBoardSpace;

--- a/lib/update/update.js
+++ b/lib/update/update.js
@@ -1,9 +1,1 @@
-'use strict';
-
-function update() {
-  return {
-    applyMoves: require('./apply-moves'),
-  };
-}
-
-module.exports = update;
+export { default as applyMoves } from './apply-moves.js';

--- a/lib/util/pairwise.js
+++ b/lib/util/pairwise.js
@@ -1,8 +1,6 @@
-'use strict';
+import _ from 'lodash';
 
-const _ = require('lodash');
-
-function pairwise(elems) {
+export default function pairwise(elems) {
   if (elems.length === 1) {
     throw new Error(
       'pairwise: Cannot create pairs from a list that only has one member'
@@ -22,5 +20,3 @@ function pairwise(elems) {
 
   return pairwiseRec([], elems);
 }
-
-module.exports = pairwise;

--- a/lib/util/repeat.js
+++ b/lib/util/repeat.js
@@ -1,9 +1,5 @@
-'use strict';
+import _ from 'lodash';
 
-const _ = require('lodash');
-
-function repeat(val, count) {
+export default function repeat(val, count) {
   return _.map(_.range(count), _.constant(val));
 }
-
-module.exports = repeat;

--- a/package.json
+++ b/package.json
@@ -3,12 +3,13 @@
   "version": "4.0.0",
   "description": "A game engine for the classic game Camelot",
   "main": "lib/camelot-engine.js",
+  "type": "module",
   "scripts": {
     "lint": "eslint .",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "lint:fix": "eslint --fix .",
-    "test": "npm run lint && npm run format && jest"
+    "test": "npm run lint && npm run format && NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "repository": {
     "type": "git",
@@ -42,5 +43,9 @@
     "ignore": [
       "lodash"
     ]
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "transform": {}
   }
 }

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -16,3 +16,5 @@ rules:
 
 extends:
   - plugin:jest/recommended
+parserOptions:
+  sourceType: module

--- a/test/camelot-engine.test.js
+++ b/test/camelot-engine.test.js
@@ -1,64 +1,72 @@
-'use strict';
-
-const camelotEngine = require('..');
+import {
+  createEmptyGame,
+  constants,
+  applyMoves,
+  isGoal,
+  isValidMove,
+  getGameWinner,
+  getBoardSpace,
+  getAllBoardSpaces,
+  getCoordsBetween,
+} from '..';
 
 describe('camelot-engine', function () {
   describe('createEmptyGame', function () {
     it('should have turnCount = 0', function () {
-      expect(camelotEngine().createEmptyGame()).toHaveProperty('turnCount', 0);
+      expect(createEmptyGame()).toHaveProperty('turnCount', 0);
     });
 
     it('should have no captured pieces', function () {
-      expect(camelotEngine().createEmptyGame().capturedPieces).toEqual({
+      expect(createEmptyGame().capturedPieces).toEqual({
         playerA: { pawn: 0, knight: 0 },
         playerB: { pawn: 0, knight: 0 },
       });
     });
 
     it('should create board spaces', function () {
-      expect(camelotEngine().createEmptyGame().boardSpaces).toHaveLength(172);
+      expect(createEmptyGame().boardSpaces).toHaveLength(172);
     });
   });
 
   describe('query', function () {
     it('exports isGoal', function () {
-      expect(typeof camelotEngine().query().isGoal).toBe('function');
+      expect(typeof isGoal).toBe('function');
     });
 
     it('exports isValidMove', function () {
-      expect(typeof camelotEngine().query().isValidMove).toBe('function');
+      expect(typeof isValidMove).toBe('function');
     });
 
     it('exports getGameWinner', function () {
-      expect(typeof camelotEngine().query().getGameWinner).toBe('function');
+      expect(typeof getGameWinner).toBe('function');
     });
 
     it('exports getBoardSpace', function () {
-      expect(typeof camelotEngine().query().getBoardSpace).toBe('function');
+      expect(typeof getBoardSpace).toBe('function');
     });
 
     it('exports getAllBoardSpaces', function () {
-      expect(typeof camelotEngine().query().getAllBoardSpaces).toBe('function');
+      expect(typeof getAllBoardSpaces).toBe('function');
     });
 
     it('exports getCoordsBetween', function () {
-      expect(typeof camelotEngine().query().getCoordsBetween).toBe('function');
+      expect(typeof getCoordsBetween).toBe('function');
     });
   });
 
   describe('update', function () {
     it('exports applyMoves', function () {
-      expect(typeof camelotEngine().update().applyMoves).toBe('function');
+      expect(typeof applyMoves).toBe('function');
     });
   });
 
   describe('constants', function () {
     it('exports KNIGHT', function () {
-      expect(typeof camelotEngine().constants().KNIGHT).toBe('string');
+      expect(typeof constants().KNIGHT).toBe('string');
     });
 
     it('exports PAWN', function () {
-      expect(typeof camelotEngine().constants().PAWN).toBe('string');
+      expect(typeof constants().PAWN).toBe('string');
     });
   });
 });

--- a/test/init/create-board-spaces.test.js
+++ b/test/init/create-board-spaces.test.js
@@ -1,7 +1,5 @@
-'use strict';
-
-const _ = require('lodash'),
-  createBoardSpaces = require('../../lib/init/create-board-spaces');
+import _ from 'lodash';
+import createBoardSpaces from '../../lib/init/create-board-spaces.js';
 
 describe('get-board-spaces', function () {
   it('should create 172 board spaces', function () {

--- a/test/init/create-empty-game.test.js
+++ b/test/init/create-empty-game.test.js
@@ -1,7 +1,5 @@
-'use strict';
-
-const getBoardSpace = require('../../lib/query/get-board-space'),
-  createEmptyGame = require('../../lib/init/create-empty-game');
+import getBoardSpace from '../../lib/query/get-board-space.js';
+import createEmptyGame from '../../lib/init/create-empty-game.js';
 
 describe('create-empty-game', function () {
   it('should have a board space at 10, 3', function () {

--- a/test/init/get-range-for-row.test.js
+++ b/test/init/get-range-for-row.test.js
@@ -1,7 +1,7 @@
-'use strict';
+import getConstants from '../../lib/get-constants.js';
+import getRangeForRow from '../../lib/init/get-range-for-row.js';
 
-const constants = require('../../lib/get-constants')(),
-  getRangeForRow = require('../../lib/init/get-range-for-row');
+const constants = getConstants();
 
 describe('get-range-for-row', function () {
   it('should create a full row', function () {

--- a/test/init/with-starting-pieces.test.js
+++ b/test/init/with-starting-pieces.test.js
@@ -1,17 +1,14 @@
-'use strict';
+import _ from 'lodash';
+import { createEmptyGame, constants, getBoardSpace } from '../..';
 
-const _ = require('lodash'),
-  camelotEngine = require('../..')(),
-  constants = camelotEngine.constants(),
-  query = camelotEngine.query(),
-  createEmptyGame = camelotEngine.createEmptyGame;
+const CONST = constants();
 
 describe('with-starting-pieces', function () {
   it('creates a board with the right number of knights', function () {
     const gameState = createEmptyGame();
     expect(
       _.filter(gameState.boardSpaces, function (boardSpace) {
-        return boardSpace.piece && boardSpace.piece.type === constants.KNIGHT;
+        return boardSpace.piece && boardSpace.piece.type === CONST.KNIGHT;
       }).length
     ).toBe(8);
   });
@@ -20,19 +17,19 @@ describe('with-starting-pieces', function () {
     const gameState = createEmptyGame();
     expect(
       _.filter(gameState.boardSpaces, function (boardSpace) {
-        return boardSpace.piece && boardSpace.piece.type === constants.PAWN;
+        return boardSpace.piece && boardSpace.piece.type === CONST.PAWN;
       }).length
     ).toBe(20);
   });
 
   it('should not have a piece at (5, 1)', function () {
     const gameState = createEmptyGame();
-    expect(query.getBoardSpace(gameState, 5, 1).piece).toBeNull();
+    expect(getBoardSpace(gameState, 5, 1).piece).toBeNull();
   });
 
   it('should not have a piece at (5, 2)', function () {
     const gameState = createEmptyGame();
-    expect(query.getBoardSpace(gameState, 5, 2).piece).toEqual({
+    expect(getBoardSpace(gameState, 5, 2).piece).toEqual({
       type: 'knight',
       player: 'playerA',
     });
@@ -40,7 +37,7 @@ describe('with-starting-pieces', function () {
 
   it('should have a piece at (5, 3)', function () {
     const gameState = createEmptyGame();
-    expect(query.getBoardSpace(gameState, 5, 3).piece).toEqual({
+    expect(getBoardSpace(gameState, 5, 3).piece).toEqual({
       type: 'pawn',
       player: 'playerA',
     });

--- a/test/query/get-board-space.test.js
+++ b/test/query/get-board-space.test.js
@@ -1,7 +1,5 @@
-'use strict';
-
-const getBoardSpace = require('../../lib/query/get-board-space'),
-  createEmptyGame = require('../../lib/init/create-empty-game');
+import getBoardSpace from '../../lib/query/get-board-space.js';
+import createEmptyGame from '../../lib/init/create-empty-game.js';
 
 describe('get-board-space', function () {
   it('returns null for an invalid board space', function () {

--- a/test/query/get-coords-between.test.js
+++ b/test/query/get-coords-between.test.js
@@ -1,6 +1,4 @@
-'use strict';
-
-const getCoordsBetween = require('../../lib/query/get-coords-between');
+import getCoordsBetween from '../../lib/query/get-coords-between.js';
 
 describe('get-coords-between', function () {
   describe('returns null when the spaces are adjacent', function () {

--- a/test/query/get-game-winner.test.js
+++ b/test/query/get-game-winner.test.js
@@ -1,11 +1,11 @@
-'use strict';
+import createEmptyGame from '../../lib/init/create-empty-game.js';
+import _ from 'lodash';
+import updateBoardSpace from '../../lib/update/update-board-space.js';
+import getConstants from '../../lib/get-constants.js';
+import getAllBoardSpaces from '../../lib/query/get-all-board-spaces.js';
+import getGameWinner from '../../lib/query/get-game-winner.js';
 
-const createEmptyGame = require('../../lib/init/create-empty-game'),
-  _ = require('lodash'),
-  updateBoardSpace = require('../../lib/update/update-board-space'),
-  constants = require('../../lib/get-constants')(),
-  getAllBoardSpaces = require('../../lib/query/get-all-board-spaces'),
-  getGameWinner = require('../../lib/query/get-game-winner');
+const constants = getConstants();
 
 describe('get-game-winner', function () {
   it('should not say that anyone has won initially', function () {

--- a/test/query/is-goal.test.js
+++ b/test/query/is-goal.test.js
@@ -1,11 +1,9 @@
-'use strict';
-
-const camelotEngine = require('../..'),
-  isGoal = require('../../lib/query/is-goal');
+import { createEmptyGame } from '../..';
+import isGoal from '../../lib/query/is-goal.js';
 
 describe('isGoal', function () {
   function getGame() {
-    return camelotEngine().createEmptyGame();
+    return createEmptyGame();
   }
 
   it('throws an error for invalid input', function () {

--- a/test/query/is-valid-move.test.js
+++ b/test/query/is-valid-move.test.js
@@ -1,9 +1,9 @@
-'use strict';
+import isValidMove from '../../lib/query/is-valid-move.js';
+import getConstants from '../../lib/get-constants.js';
+import updateBoardSpace from '../../lib/update/update-board-space.js';
+import createEmptyGame from '../../lib/init/create-empty-game.js';
 
-const isValidMove = require('../../lib/query/is-valid-move'),
-  constants = require('../../lib/get-constants')(),
-  updateBoardSpace = require('../../lib/update/update-board-space'),
-  createEmptyGame = require('../../lib/init/create-empty-game');
+const constants = getConstants();
 
 describe('is-valid-move', function () {
   it('empty moves are valid', function () {

--- a/test/update/apply-move.test.js
+++ b/test/update/apply-move.test.js
@@ -1,10 +1,10 @@
-'use strict';
+import createEmptyGame from '../../lib/init/create-empty-game.js';
+import updateBoardSpace from '../../lib/update/update-board-space.js';
+import getBoardSpace from '../../lib/query/get-board-space.js';
+import getConstants from '../../lib/get-constants.js';
+import applyMove from '../../lib/update/apply-move.js';
 
-const createEmptyGame = require('../../lib/init/create-empty-game'),
-  updateBoardSpace = require('../../lib/update/update-board-space'),
-  getBoardSpace = require('../../lib/query/get-board-space'),
-  constants = require('../../lib/get-constants')(),
-  applyMove = require('../../lib/update/apply-move');
+const constants = getConstants();
 
 describe('apply-move', function () {
   it('adds a piece to the destination', function () {

--- a/test/update/apply-moves.test.js
+++ b/test/update/apply-moves.test.js
@@ -1,10 +1,10 @@
-'use strict';
+import createEmptyGame from '../../lib/init/create-empty-game.js';
+import updateBoardSpace from '../../lib/update/update-board-space.js';
+import getBoardSpace from '../../lib/query/get-board-space.js';
+import getConstants from '../../lib/get-constants.js';
+import applyMoves from '../../lib/update/apply-moves.js';
 
-const createEmptyGame = require('../../lib/init/create-empty-game'),
-  updateBoardSpace = require('../../lib/update/update-board-space'),
-  getBoardSpace = require('../../lib/query/get-board-space'),
-  constants = require('../../lib/get-constants')(),
-  applyMoves = require('../../lib/update/apply-moves');
+const constants = getConstants();
 
 describe('apply-moves', function () {
   it('adds a piece to the destination', function () {

--- a/test/update/update-board-space.test.js
+++ b/test/update/update-board-space.test.js
@@ -1,9 +1,5 @@
-'use strict';
-
-const updateBoardSpace = require('../../lib/update/update-board-space'),
-  camelotEngine = require('../..')(),
-  createEmptyGame = camelotEngine.createEmptyGame,
-  getBoardSpace = camelotEngine.query().getBoardSpace;
+import updateBoardSpace from '../../lib/update/update-board-space.js';
+import { createEmptyGame, getBoardSpace } from '../..';
 
 describe('updateBoardSpace', function () {
   it('updates a board space', function () {

--- a/test/update/update.test.js
+++ b/test/update/update.test.js
@@ -1,9 +1,7 @@
-'use strict';
-
-const update = require('../../lib/update/update');
+import { applyMoves } from '../../lib/update/update.js';
 
 describe('update', function () {
   it('exports applyMoves', function () {
-    expect(typeof update().applyMoves).toBe('function');
+    expect(typeof applyMoves).toBe('function');
   });
 });

--- a/test/util/pairwise.test.js
+++ b/test/util/pairwise.test.js
@@ -1,7 +1,5 @@
-'use strict';
-
-const _ = require('lodash'),
-  pairwise = require('../../lib/util/pairwise');
+import _ from 'lodash';
+import pairwise from '../../lib/util/pairwise.js';
 
 describe('pairwise', function () {
   it('returns an empty list for empty input', function () {


### PR DESCRIPTION
## Summary
- add `ecmaVersion` to ESLint config so modern syntax like `export *` works
- simplify public modules to use named exports
- update tests to import the new named exports
- set `NODE_OPTIONS=--experimental-vm-modules` when running jest

## Testing
- `npm test`
