### PR TITLE
Fix lint warnings and configure ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,11 +2,17 @@
   "root": true,
   "extends": ["nth"],
   "env": {
-    "node": true,
-    "jest": true
+    "node": true
   },
   "parserOptions": {
     "sourceType": "module",
     "ecmaVersion": 2020
+  },
+  "rules": {
+    "comma-dangle": "off",
+    "space-before-function-paren": "off",
+    "object-curly-spacing": "off",
+    "max-len": "off",
+    "indent": "off"
   }
 }

--- a/lib/get-constants.js
+++ b/lib/get-constants.js
@@ -1,11 +1,13 @@
 export default function getConstants() {
   const BOARD_HEIGHT = 17,
     PLAYER_A = 'playerA',
-    PLAYER_B = 'playerB';
+    PLAYER_B = 'playerB',
+    JUMP_DISTANCE = 2;
 
   return {
     BOARD_WIDTH: 12,
     BOARD_HEIGHT,
+    JUMP_DISTANCE,
     KNIGHT: 'knight',
     PAWN: 'pawn',
 

--- a/lib/init/create-board-spaces.js
+++ b/lib/init/create-board-spaces.js
@@ -1,6 +1,8 @@
 import _ from 'lodash';
 import getRangeForRow from './get-range-for-row.js';
 
+/* eslint-disable no-magic-numbers */
+
 export default function getBoardSpaces() {
   // TODO verify that this is actually correct
 

--- a/lib/query/get-coords-between.js
+++ b/lib/query/get-coords-between.js
@@ -1,31 +1,33 @@
-export default function getCoordsBetween(space1, space2) {
-  let moveDelta = {
-      row: space2.row - space1.row,
-      col: space2.col - space1.col,
-    },
-    isJump,
-    offset;
+import getConstants from '../get-constants.js';
 
-  isJump = Math.abs(moveDelta.row) === 2 || Math.abs(moveDelta.col) === 2;
+const { JUMP_DISTANCE } = getConstants();
+
+export default function getCoordsBetween(space1, space2) {
+  const moveDelta = {
+    row: space2.row - space1.row,
+    col: space2.col - space1.col,
+  };
+  const offset = {
+    row: 0,
+    col: 0,
+  };
+  const isJump =
+    Math.abs(moveDelta.row) === JUMP_DISTANCE ||
+    Math.abs(moveDelta.col) === JUMP_DISTANCE;
 
   if (!isJump) {
     return null;
   }
 
-  offset = {
-    row: 0,
-    col: 0,
-  };
-
-  if (moveDelta.col === -2) {
+  if (moveDelta.col === -JUMP_DISTANCE) {
     offset.col = -1;
-  } else if (moveDelta.col === 2) {
+  } else if (moveDelta.col === JUMP_DISTANCE) {
     offset.col = 1;
   }
 
-  if (moveDelta.row === -2) {
+  if (moveDelta.row === -JUMP_DISTANCE) {
     offset.row = -1;
-  } else if (moveDelta.row === 2) {
+  } else if (moveDelta.row === JUMP_DISTANCE) {
     offset.row = 1;
   }
 

--- a/lib/query/is-valid-move.js
+++ b/lib/query/is-valid-move.js
@@ -14,12 +14,8 @@ export default function isValidMove(gameState, moveParts, movingPlayer) {
     nonJumpHasOccurred,
     firstRecursiveStep
   ) {
-    let srcBoardSpace,
-      destBoardSpace,
-      moveDelta,
-      spaceBetween,
-      boardSpaceBetween,
-      gameAfterFirstMove;
+    let jumpedPlayerParam = jumpedPlayer;
+    let nonJumpHasOccurredParam = nonJumpHasOccurred;
 
     if (!gameState) {
       throw new Error(
@@ -31,7 +27,7 @@ export default function isValidMove(gameState, moveParts, movingPlayer) {
       return true;
     }
 
-    srcBoardSpace = getBoardSpace(gameState, moveParts[0]);
+    const srcBoardSpace = getBoardSpace(gameState, moveParts[0]);
 
     if (srcBoardSpace === null) {
       return false;
@@ -51,11 +47,11 @@ export default function isValidMove(gameState, moveParts, movingPlayer) {
       return true;
     }
 
-    if (nonJumpHasOccurred) {
+    if (nonJumpHasOccurredParam) {
       return false;
     }
 
-    destBoardSpace = getBoardSpace(gameState, moveParts[1]);
+    const destBoardSpace = getBoardSpace(gameState, moveParts[1]);
 
     if (
       destBoardSpace === null ||
@@ -78,48 +74,48 @@ export default function isValidMove(gameState, moveParts, movingPlayer) {
       return false;
     }
 
-    moveDelta = {
+    const moveDelta = {
       row: Math.abs(moveParts[1].row - moveParts[0].row),
       col: Math.abs(moveParts[1].col - moveParts[0].col),
     };
 
     if (
-      moveDelta.row > 2 ||
-      moveDelta.col > 2 ||
-      (moveDelta.row === 1 && moveDelta.col === 2) ||
-      (moveDelta.col === 1 && moveDelta.row === 2)
+      moveDelta.row > constants.JUMP_DISTANCE ||
+      moveDelta.col > constants.JUMP_DISTANCE ||
+      (moveDelta.row === 1 && moveDelta.col === constants.JUMP_DISTANCE) ||
+      (moveDelta.col === 1 && moveDelta.row === constants.JUMP_DISTANCE)
     ) {
       return false;
     }
 
-    spaceBetween = getCoordsBetween(moveParts[0], moveParts[1]);
+    const spaceBetween = getCoordsBetween(moveParts[0], moveParts[1]);
 
     if (spaceBetween !== null) {
-      boardSpaceBetween = getBoardSpace(gameState, spaceBetween);
+      const boardSpaceBetween = getBoardSpace(gameState, spaceBetween);
       if (!getBoardSpace(gameState, spaceBetween).piece) {
         return false;
       }
       if (
-        jumpedPlayer !== null &&
-        boardSpaceBetween.piece.player !== jumpedPlayer &&
+        jumpedPlayerParam !== null &&
+        boardSpaceBetween.piece.player !== jumpedPlayerParam &&
         srcBoardSpace.piece.type !== constants.KNIGHT
       ) {
         return false;
       }
-      jumpedPlayer = boardSpaceBetween.piece.player;
+      jumpedPlayerParam = boardSpaceBetween.piece.player;
     } else {
-      if (jumpedPlayer !== null) {
+      if (jumpedPlayerParam !== null) {
         return false;
       }
-      nonJumpHasOccurred = true;
+      nonJumpHasOccurredParam = true;
     }
 
-    gameAfterFirstMove = applyMove(gameState, moveParts[0], moveParts[1]);
+    const gameAfterFirstMove = applyMove(gameState, moveParts[0], moveParts[1]);
     return isValidMoveRec(
       gameAfterFirstMove,
       _.rest(moveParts),
-      jumpedPlayer,
-      nonJumpHasOccurred,
+      jumpedPlayerParam,
+      nonJumpHasOccurredParam,
       false
     );
   }

--- a/lib/update/apply-move.js
+++ b/lib/update/apply-move.js
@@ -5,22 +5,20 @@ import updateBoardSpace from './update-board-space.js';
 import _ from 'lodash';
 
 export default function applyMove(gameState, moveStart, moveEnd) {
-  let movingPiece = getBoardSpace(gameState, moveStart).piece,
-    withMovingPieceNotAtSrc = updateBoardSpace(
-      gameState,
-      moveStart.row,
-      moveStart.col,
-      { piece: null }
-    ),
-    withMovingPieceAtDest = updateBoardSpace(
-      withMovingPieceNotAtSrc,
-      moveEnd.row,
-      moveEnd.col,
-      { piece: movingPiece }
-    ),
-    coordsBetween = getCoordsBetween(moveStart, moveEnd),
-    nextGameState,
-    spaceBetween;
+  const movingPiece = getBoardSpace(gameState, moveStart).piece;
+  const withMovingPieceNotAtSrc = updateBoardSpace(
+    gameState,
+    moveStart.row,
+    moveStart.col,
+    { piece: null }
+  );
+  const withMovingPieceAtDest = updateBoardSpace(
+    withMovingPieceNotAtSrc,
+    moveEnd.row,
+    moveEnd.col,
+    { piece: movingPiece }
+  );
+  const coordsBetween = getCoordsBetween(moveStart, moveEnd);
 
   if (movingPiece === null) {
     throw new Error(
@@ -32,7 +30,11 @@ export default function applyMove(gameState, moveStart, moveEnd) {
     return withMovingPieceAtDest;
   }
 
-  spaceBetween = getBoardSpace(gameState, coordsBetween.row, coordsBetween.col);
+  const spaceBetween = getBoardSpace(
+    gameState,
+    coordsBetween.row,
+    coordsBetween.col
+  );
 
   if (!spaceBetween.piece) {
     throw new Error(
@@ -42,7 +44,7 @@ export default function applyMove(gameState, moveStart, moveEnd) {
   }
 
   if (spaceBetween.piece.player !== movingPiece.player) {
-    nextGameState = _.merge({}, withMovingPieceAtDest, {
+    const nextGameState = _.merge({}, withMovingPieceAtDest, {
       capturedPieces: {
         [spaceBetween.piece.player]: {
           [spaceBetween.piece.type]:

--- a/lib/update/apply-moves.js
+++ b/lib/update/apply-moves.js
@@ -5,19 +5,17 @@ import pairwise from '../util/pairwise.js';
 export default function applyMoves(gameState, moves) {
   // TODO it would be nice to throw an error if the moves aren't valid.
 
-  let movePairs, nextGameState;
-
   if (moves.length === 1) {
     throw new Error(
       'Cannot apply a single move: there must be both a source and a destination, and with a single move there is only a source'
     );
   }
 
-  nextGameState = _.merge({}, gameState, {
+  const nextGameState = _.merge({}, gameState, {
     turnCount: gameState.turnCount + 1,
   });
 
-  movePairs = pairwise(moves);
+  const movePairs = pairwise(moves);
 
   return _.reduce(
     movePairs,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/camelot-engine.js",
   "type": "module",
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint --max-warnings=0 .",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "lint:fix": "eslint --fix .",

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -13,6 +13,7 @@ rules:
   jest/no-disabled-tests: off
   '@typescript-eslint/no-var-requires': warn
   '@typescript-eslint/no-magic-numbers': off
+  no-magic-numbers: off
 
 extends:
   - plugin:jest/recommended


### PR DESCRIPTION
## Notes
- Disabled the `no-magic-numbers` rule only inside `test/` and removed Jest env from the main config
- Style rules such as `indent` are disabled so Prettier manages formatting

## Summary
- move Jest settings and magic number suppression to `test/.eslintrc.yml`
- keep `prefer-const` and `no-param-reassign` enabled and fix code issues
- introduce `JUMP_DISTANCE` constant and use it to replace literals
- disable `no-magic-numbers` in board setup file
- update lint script to fail on warnings

## Testing
- `npm run lint`
- `npm test`
