### PR TITLE
Display usernames in game view

### DIFF
--- a/.cursor/rules/finish.mdc
+++ b/.cursor/rules/finish.mdc
@@ -3,9 +3,13 @@ description:
 globs: 
 alwaysApply: false
 ---
-You're on a branch from another coding agent. It's partially complete, but you need to verify that everything is working, and/or do what that agent couldn't. Finish it.
+I'll give you a branch from another coding agent. It's partially complete, but you need to verify that everything is working, and/or do what that agent couldn't. Finish it.
 
 <steps>
+  <step>
+  `git fetch origin`
+  `git checkout {the branch name I gave you}`
+  </step>
   <step>
   Run these two commands to get a sense of what the previous agent was doing: 
   * `git --no-pager diff (git merge-base master HEAD)..HEAD`

--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -16,10 +16,10 @@ If your changes can be verified by updating the unit test suite (e.g. adding or 
 If tests fail, fix the issues before proceeding. The full test suite should pass before any work is considered complete.
 
 ## Workflow Gudelines
-When you're done, write your own commit message. Identify yourself.
+When you're done, write your own commit message. Identify yourself as Cursor.
 
 ## Env Guidelines
-Only run `npm run dev` if the 
+Only run `npm run dev` if the server isn't already running. I may have already launched it for you.
 
 ## General Guidelines
 

--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -18,6 +18,9 @@ If tests fail, fix the issues before proceeding. The full test suite should pass
 ## Workflow Gudelines
 When you're done, write your own commit message. Identify yourself.
 
+## Env Guidelines
+Only run `npm run dev` if the 
+
 ## General Guidelines
 
 - Follow the architectural guidance in AGENTS.md

--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -17,8 +17,8 @@ If tests fail, fix the issues before proceeding. The full test suite should pass
 
 ## Workflow Gudelines
 When you're done:
-1. Ask the user if 
-When you're done and  confirmed that it works, write your own commit message. Identify yourself as Cursor.
+1. Ask the user if your code works and you're ready to commit
+2. When they confirm, write your own commit message and identify yourself as Cursor.
 
 ## Env Guidelines
 Only run `npm run dev` if the server isn't already running. I may have already launched it for you.

--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -16,10 +16,14 @@ If your changes can be verified by updating the unit test suite (e.g. adding or 
 If tests fail, fix the issues before proceeding. The full test suite should pass before any work is considered complete.
 
 ## Workflow Gudelines
-When you're done, write your own commit message. Identify yourself as Cursor.
+When you're done:
+1. Ask the user if 
+When you're done and  confirmed that it works, write your own commit message. Identify yourself as Cursor.
 
 ## Env Guidelines
 Only run `npm run dev` if the server isn't already running. I may have already launched it for you.
+
+You do not need to stop the dev server to run tests.
 
 ## General Guidelines
 

--- a/components/game/game-board-preloaded.tsx
+++ b/components/game/game-board-preloaded.tsx
@@ -150,7 +150,7 @@ export function GameBoardPreloaded({
       <div className="flex space-x-8 text-sm">
         <div className="bg-red-50 dark:bg-red-950/20 p-4 rounded-lg border border-red-200 dark:border-red-800">
           <strong className="text-red-700 dark:text-red-400">
-            {playerAName} (Red):
+            {playerAName}:
           </strong>
           <div className="mt-2 text-gray-700 dark:text-gray-300">
             Knights captured: {game.capturedPieces.playerB.knight}
@@ -161,7 +161,7 @@ export function GameBoardPreloaded({
         </div>
         <div className="bg-blue-50 dark:bg-blue-950/20 p-4 rounded-lg border border-blue-200 dark:border-blue-800">
           <strong className="text-blue-700 dark:text-blue-400">
-            {playerBName} (Blue):
+            {playerBName}:
           </strong>
           <div className="mt-2 text-gray-700 dark:text-gray-300">
             Knights captured: {game.capturedPieces.playerA.knight}

--- a/components/game/game-board-preloaded.tsx
+++ b/components/game/game-board-preloaded.tsx
@@ -9,9 +9,13 @@ import { findBoardSpace } from '@/lib/game-utils';
 
 interface GameBoardPreloadedProps {
   preloadedGame: Preloaded<typeof api.games.getGame>;
+  players: Record<string, { username: string | null; email: string }>;
 }
 
-export function GameBoardPreloaded({ preloadedGame }: GameBoardPreloadedProps) {
+export function GameBoardPreloaded({
+  preloadedGame,
+  players,
+}: GameBoardPreloadedProps) {
   // This hook hydrates the preloaded data AND subscribes to real-time updates
   const gameData = usePreloadedQuery(preloadedGame);
   const [selectedSpace, setSelectedSpace] = useState<Coordinates | null>(null);
@@ -23,14 +27,21 @@ export function GameBoardPreloaded({ preloadedGame }: GameBoardPreloadedProps) {
     return <div className="text-center text-red-500">Game not found</div>;
   }
 
-  const { game, boardSpaces, playerAName, playerBName } = gameData;
+  const { game, boardSpaces } = gameData;
 
   const isMyTurn =
     game.status === 'playing' &&
     ((game.currentPlayer === 'playerA' && game.playerA === currentUserId) ||
       (game.currentPlayer === 'playerB' && game.playerB === currentUserId));
 
-  const currentPlayerName =
+  // Get player display names
+  const playerAName =
+    players.playerA?.username || players.playerA?.email || 'Player A';
+  const playerBName =
+    players.playerB?.username || players.playerB?.email || 'Player B';
+
+  // For turn display, show the appropriate name
+  const currentTurnName =
     game.currentPlayer === 'playerA' ? playerAName : playerBName;
 
   const winnerName =
@@ -120,11 +131,8 @@ export function GameBoardPreloaded({ preloadedGame }: GameBoardPreloadedProps) {
       <div className="text-lg font-semibold">
         {game.status === 'waiting' && 'Waiting for opponent...'}
         {game.status === 'playing' &&
-          (isMyTurn
-            ? 'Your turn'
-            : `${currentPlayerName ?? game.currentPlayer}'s turn`)}
-        {game.status === 'completed' &&
-          `Winner: ${winnerName ?? game.winner ?? ''}`}
+          (isMyTurn ? 'Your turn' : `${currentTurnName}'s turn`)}
+        {game.status === 'completed' && `Winner: ${winnerName}`}
       </div>
 
       <div className="bg-gray-200 dark:bg-gray-800 p-4 rounded-lg shadow-xl">
@@ -142,7 +150,7 @@ export function GameBoardPreloaded({ preloadedGame }: GameBoardPreloadedProps) {
       <div className="flex space-x-8 text-sm">
         <div className="bg-red-50 dark:bg-red-950/20 p-4 rounded-lg border border-red-200 dark:border-red-800">
           <strong className="text-red-700 dark:text-red-400">
-            {playerAName ?? 'Player A'} (Red):
+            {playerAName} (Red):
           </strong>
           <div className="mt-2 text-gray-700 dark:text-gray-300">
             Knights captured: {game.capturedPieces.playerB.knight}
@@ -153,7 +161,7 @@ export function GameBoardPreloaded({ preloadedGame }: GameBoardPreloadedProps) {
         </div>
         <div className="bg-blue-50 dark:bg-blue-950/20 p-4 rounded-lg border border-blue-200 dark:border-blue-800">
           <strong className="text-blue-700 dark:text-blue-400">
-            {playerBName ?? 'Player B'} (Blue):
+            {playerBName} (Blue):
           </strong>
           <div className="mt-2 text-gray-700 dark:text-gray-300">
             Knights captured: {game.capturedPieces.playerA.knight}

--- a/components/game/game-board-preloaded.tsx
+++ b/components/game/game-board-preloaded.tsx
@@ -23,12 +23,22 @@ export function GameBoardPreloaded({ preloadedGame }: GameBoardPreloadedProps) {
     return <div className="text-center text-red-500">Game not found</div>;
   }
 
-  const { game, boardSpaces } = gameData;
+  const { game, boardSpaces, playerAName, playerBName } = gameData;
 
   const isMyTurn =
     game.status === 'playing' &&
     ((game.currentPlayer === 'playerA' && game.playerA === currentUserId) ||
       (game.currentPlayer === 'playerB' && game.playerB === currentUserId));
+
+  const otherPlayerName =
+    currentUserId === game.playerA ? playerBName : playerAName;
+
+  const winnerName =
+    game.winner === 'playerA'
+      ? playerAName
+      : game.winner === 'playerB'
+        ? playerBName
+        : null;
 
   const handleSpaceClick = async (row: number, col: number) => {
     if (!isMyTurn) return;
@@ -110,8 +120,9 @@ export function GameBoardPreloaded({ preloadedGame }: GameBoardPreloadedProps) {
       <div className="text-lg font-semibold">
         {game.status === 'waiting' && 'Waiting for opponent...'}
         {game.status === 'playing' &&
-          (isMyTurn ? 'Your turn' : `${game.currentPlayer}'s turn`)}
-        {game.status === 'completed' && `Winner: ${game.winner}`}
+          (isMyTurn ? 'Your turn' : `${otherPlayerName ?? 'Opponent'}'s turn`)}
+        {game.status === 'completed' &&
+          `Winner: ${winnerName ?? game.winner ?? ''}`}
       </div>
 
       <div className="bg-gray-200 dark:bg-gray-800 p-4 rounded-lg shadow-xl">
@@ -129,7 +140,7 @@ export function GameBoardPreloaded({ preloadedGame }: GameBoardPreloadedProps) {
       <div className="flex space-x-8 text-sm">
         <div className="bg-red-50 dark:bg-red-950/20 p-4 rounded-lg border border-red-200 dark:border-red-800">
           <strong className="text-red-700 dark:text-red-400">
-            Player A (Red):
+            {playerAName ?? 'Player A'} (Red):
           </strong>
           <div className="mt-2 text-gray-700 dark:text-gray-300">
             Knights captured: {game.capturedPieces.playerB.knight}
@@ -140,7 +151,7 @@ export function GameBoardPreloaded({ preloadedGame }: GameBoardPreloadedProps) {
         </div>
         <div className="bg-blue-50 dark:bg-blue-950/20 p-4 rounded-lg border border-blue-200 dark:border-blue-800">
           <strong className="text-blue-700 dark:text-blue-400">
-            Player B (Blue):
+            {playerBName ?? 'Player B'} (Blue):
           </strong>
           <div className="mt-2 text-gray-700 dark:text-gray-300">
             Knights captured: {game.capturedPieces.playerA.knight}

--- a/components/game/game-board-preloaded.tsx
+++ b/components/game/game-board-preloaded.tsx
@@ -30,8 +30,8 @@ export function GameBoardPreloaded({ preloadedGame }: GameBoardPreloadedProps) {
     ((game.currentPlayer === 'playerA' && game.playerA === currentUserId) ||
       (game.currentPlayer === 'playerB' && game.playerB === currentUserId));
 
-  const otherPlayerName =
-    currentUserId === game.playerA ? playerBName : playerAName;
+  const currentPlayerName =
+    game.currentPlayer === 'playerA' ? playerAName : playerBName;
 
   const winnerName =
     game.winner === 'playerA'
@@ -120,7 +120,9 @@ export function GameBoardPreloaded({ preloadedGame }: GameBoardPreloadedProps) {
       <div className="text-lg font-semibold">
         {game.status === 'waiting' && 'Waiting for opponent...'}
         {game.status === 'playing' &&
-          (isMyTurn ? 'Your turn' : `${otherPlayerName ?? 'Opponent'}'s turn`)}
+          (isMyTurn
+            ? 'Your turn'
+            : `${currentPlayerName ?? game.currentPlayer}'s turn`)}
         {game.status === 'completed' &&
           `Winner: ${winnerName ?? game.winner ?? ''}`}
       </div>

--- a/convex/games.ts
+++ b/convex/games.ts
@@ -53,6 +53,20 @@ export const getGame = query({
     const game = await ctx.db.get(args.gameId);
     if (!game) return null;
 
+    const playerAUser = game.playerA
+      ? await ctx.db
+          .query('users')
+          .withIndex('by_clerk_id', (q) => q.eq('clerkId', game.playerA!))
+          .unique()
+      : null;
+
+    const playerBUser = game.playerB
+      ? await ctx.db
+          .query('users')
+          .withIndex('by_clerk_id', (q) => q.eq('clerkId', game.playerB!))
+          .unique()
+      : null;
+
     const moves = await ctx.db
       .query('moves')
       .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
@@ -63,6 +77,8 @@ export const getGame = query({
       game,
       boardSpaces: game.boardSpaces,
       moves,
+      playerAName: playerAUser?.username ?? null,
+      playerBName: playerBUser?.username ?? null,
     };
   },
 });

--- a/convex/games.ts
+++ b/convex/games.ts
@@ -53,20 +53,6 @@ export const getGame = query({
     const game = await ctx.db.get(args.gameId);
     if (!game) return null;
 
-    const playerAUser = game.playerA
-      ? await ctx.db
-          .query('users')
-          .withIndex('by_clerk_id', (q) => q.eq('clerkId', game.playerA!))
-          .unique()
-      : null;
-
-    const playerBUser = game.playerB
-      ? await ctx.db
-          .query('users')
-          .withIndex('by_clerk_id', (q) => q.eq('clerkId', game.playerB!))
-          .unique()
-      : null;
-
     const moves = await ctx.db
       .query('moves')
       .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
@@ -77,8 +63,6 @@ export const getGame = query({
       game,
       boardSpaces: game.boardSpaces,
       moves,
-      playerAName: playerAUser?.username ?? null,
-      playerBName: playerBUser?.username ?? null,
     };
   },
 });


### PR DESCRIPTION
## Summary
- include player names in `getGame` query
- show "Your turn" or opponent's name during play
- use usernames in captured pieces display

## Testing
- `npm test` *(fails: Failed to fetch fonts during Next.js build)*

------
https://chatgpt.com/codex/tasks/task_e_68571cd499f88326b3024d9ed4dd74f7